### PR TITLE
added missing ref to config.cpp for env:motor

### DIFF
--- a/sw/include/config.h
+++ b/sw/include/config.h
@@ -4,8 +4,6 @@
 
 #include <Arduino.h>
 
-
-
 enum motorType_t
 {
     SINGLE,
@@ -21,10 +19,9 @@ enum steerType_t
 class Config
 {
 private:
+public:
     uint64_t ID = 0;
     String NAME;
-
-public:
     Config(void);
     void Begin(void);
 

--- a/sw/platformio.ini
+++ b/sw/platformio.ini
@@ -37,7 +37,7 @@ platform = espressif32@3.5.0
 board = esp32dev
 framework = arduino
 build_flags = -v
-build_src_filter = -<*.cpp> +<z_main_motor.cpp> +<actuators/*.cpp>
+build_src_filter = -<*.cpp> +<z_main_motor.cpp> +<actuators/*.cpp> +<config.cpp>
 monitor_speed = 57600
 lib_deps = 
 	ricaun/ArduinoUniqueID@^1.3.0

--- a/sw/platformio.ini
+++ b/sw/platformio.ini
@@ -47,7 +47,6 @@ platform = espressif32@3.5.0
 board = esp32dev
 framework = arduino
 lib_deps = 
-	ricaun/ArduinoUniqueID@^1.3.03
 build_flags = -v
 build_src_filter = -<*.cpp> +<z_main_config.cpp> +<config.cpp> +<logger.cpp>
 monitor_speed = 57600

--- a/sw/src/z_main_config.cpp
+++ b/sw/src/z_main_config.cpp
@@ -5,6 +5,7 @@ Config conf;
 void setup() {
   Serial.begin(57600);
   Serial.println("initiated");
+  conf.Begin();
 }
 
 void loop() {


### PR DESCRIPTION
Minor update to fix regression prolem as z_main_motor id not build.


Now verified with:
motor
usensor
accsensor
steer